### PR TITLE
fix typo with "contruis"

### DIFF
--- a/marcel.go
+++ b/marcel.go
@@ -11,7 +11,7 @@ import (
 var (
 	actions = map[string]string{
 		"attache":     "attach",
-		"construis":   "build",
+		"construit":   "build",
 		"engage":      "commit",
 		"copie":       "cp",
 		"crée":        "create",


### PR DESCRIPTION
correct grammar for "construire" verb, using 3rd person of indicative present is "construit"
http://la-conjugaison.nouvelobs.com/du/verbe/construire.php
marcel construit -t majolie/image .
